### PR TITLE
feat: Implement storage manager based on file system

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,7 @@ dependencies {
     annotationProcessor 'org.projectlombok:lombok'
 
     // AWS S3
-    implementation 'software.amazon.awssdk:s3:2.25.27'
+    implementation 'software.amazon.awssdk:s3:2.29.9'
 
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
 
+    // AWS S3
+    implementation 'software.amazon.awssdk:s3:2.25.27'
+
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }

--- a/src/main/java/aubergine/dance/config/AwsS3Config.java
+++ b/src/main/java/aubergine/dance/config/AwsS3Config.java
@@ -1,0 +1,30 @@
+package aubergine.dance.config;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@EnableConfigurationProperties(AwsS3CredentialProperties.class)
+@RequiredArgsConstructor
+public class AwsS3Config {
+
+    private final AwsS3CredentialProperties awsS3CredentialProperties;
+
+    @Bean
+    public S3Client s3Client() {
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(
+                awsS3CredentialProperties.accessKey(),
+                awsS3CredentialProperties.secretKey()
+        );
+        return S3Client.builder()
+                .region(Region.of(awsS3CredentialProperties.region()))
+                .credentialsProvider(StaticCredentialsProvider.create(credentials))
+                .build();
+    }
+}

--- a/src/main/java/aubergine/dance/config/AwsS3CredentialProperties.java
+++ b/src/main/java/aubergine/dance/config/AwsS3CredentialProperties.java
@@ -1,0 +1,7 @@
+package aubergine.dance.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "aws.s3.credentials")
+public record AwsS3CredentialProperties(String region, String accessKey, String secretKey) {
+}

--- a/src/main/java/aubergine/dance/config/StorageManagerConfig.java
+++ b/src/main/java/aubergine/dance/config/StorageManagerConfig.java
@@ -5,7 +5,6 @@ import aubergine.dance.service.local.LocalFileStorageManager;
 import aubergine.dance.service.s3.AwsS3Properties;
 import aubergine.dance.service.s3.S3StorageManager;
 import lombok.RequiredArgsConstructor;
-import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -27,7 +26,7 @@ public class StorageManagerConfig {
     }
 
     @Bean
-    @Profile({"dev", "prod"})
+    @Profile("s3")
     public StorageManager s3StorageManager() {
         return new S3StorageManager(s3Client, awsS3Properties);
     }

--- a/src/main/java/aubergine/dance/config/StorageManagerConfig.java
+++ b/src/main/java/aubergine/dance/config/StorageManagerConfig.java
@@ -1,0 +1,34 @@
+package aubergine.dance.config;
+
+import aubergine.dance.service.StorageManager;
+import aubergine.dance.service.local.LocalFileStorageManager;
+import aubergine.dance.service.s3.AwsS3Properties;
+import aubergine.dance.service.s3.S3StorageManager;
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import software.amazon.awssdk.services.s3.S3Client;
+
+@Configuration
+@EnableConfigurationProperties(AwsS3Properties.class)
+@RequiredArgsConstructor
+public class StorageManagerConfig {
+
+    private final S3Client s3Client;
+    private final AwsS3Properties awsS3Properties;
+
+    @Bean
+    @Profile("local")
+    public StorageManager localFileStorageManager() {
+        return new LocalFileStorageManager();
+    }
+
+    @Bean
+    @Profile({"dev", "prod"})
+    public StorageManager s3StorageManager() {
+        return new S3StorageManager(s3Client, awsS3Properties);
+    }
+}

--- a/src/main/java/aubergine/dance/service/ProblemAlreadyExistsException.java
+++ b/src/main/java/aubergine/dance/service/ProblemAlreadyExistsException.java
@@ -1,0 +1,12 @@
+package aubergine.dance.service;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class ProblemAlreadyExistsException extends RuntimeException {
+
+    public ProblemAlreadyExistsException(long problemId) {
+        super("Problem with id " + problemId + " already exists");
+        log.error("Problem with id {} already exists", problemId);
+    }
+}

--- a/src/main/java/aubergine/dance/service/ProblemInitDirectories.java
+++ b/src/main/java/aubergine/dance/service/ProblemInitDirectories.java
@@ -1,0 +1,8 @@
+package aubergine.dance.service;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "aubergine.init")
+public record ProblemInitDirectories(List<String> directories) {
+}

--- a/src/main/java/aubergine/dance/service/ProblemInitializer.java
+++ b/src/main/java/aubergine/dance/service/ProblemInitializer.java
@@ -1,0 +1,26 @@
+package aubergine.dance.service;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Service;
+
+@Service
+@EnableConfigurationProperties(ProblemInitDirectories.class)
+@RequiredArgsConstructor
+@Slf4j
+public class ProblemInitializer {
+
+    private final StorageManager storageManager;
+    private final ProblemInitDirectories problemInitDirectories;
+
+    public void initializeProblem(long problemId) {
+        if (storageManager.isDirectoryExists(problemId + "/")) {
+            throw new ProblemAlreadyExistsException(problemId);
+        }
+
+        for (String directory : problemInitDirectories.directories()) {
+            storageManager.createDirectory(problemId + "/" + directory);
+        }
+    }
+}

--- a/src/main/java/aubergine/dance/service/StorageManager.java
+++ b/src/main/java/aubergine/dance/service/StorageManager.java
@@ -1,0 +1,8 @@
+package aubergine.dance.service;
+
+public interface StorageManager {
+
+    void createDirectory(String directory);
+
+    boolean isDirectoryExists(String directory);
+}

--- a/src/main/java/aubergine/dance/service/local/LocalFileStorageManager.java
+++ b/src/main/java/aubergine/dance/service/local/LocalFileStorageManager.java
@@ -2,11 +2,7 @@ package aubergine.dance.service.local;
 
 import aubergine.dance.service.StorageManager;
 import java.io.File;
-import org.springframework.context.annotation.Profile;
-import org.springframework.stereotype.Component;
 
-@Profile("local")
-@Component
 public class LocalFileStorageManager implements StorageManager {
 
     @Override

--- a/src/main/java/aubergine/dance/service/local/LocalFileStorageManager.java
+++ b/src/main/java/aubergine/dance/service/local/LocalFileStorageManager.java
@@ -1,0 +1,25 @@
+package aubergine.dance.service.local;
+
+import aubergine.dance.service.StorageManager;
+import java.io.File;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+@Profile("local")
+@Component
+public class LocalFileStorageManager implements StorageManager {
+
+    @Override
+    public void createDirectory(String directory) {
+        File file = new File(directory);
+        if (!file.exists()) {
+            file.mkdirs();
+        }
+    }
+
+    @Override
+    public boolean isDirectoryExists(String directory) {
+        File file = new File(directory);
+        return file.exists();
+    }
+}

--- a/src/main/java/aubergine/dance/service/local/LocalFileStorageManager.java
+++ b/src/main/java/aubergine/dance/service/local/LocalFileStorageManager.java
@@ -7,10 +7,11 @@ public class LocalFileStorageManager implements StorageManager {
 
     @Override
     public void createDirectory(String directory) {
-        File file = new File(directory);
-        if (!file.exists()) {
-            file.mkdirs();
+        if (isDirectoryExists(directory)) {
+            return;
         }
+        File file = new File(directory);
+        file.mkdirs();
     }
 
     @Override

--- a/src/main/java/aubergine/dance/service/s3/AwsS3Properties.java
+++ b/src/main/java/aubergine/dance/service/s3/AwsS3Properties.java
@@ -1,0 +1,7 @@
+package aubergine.dance.service.s3;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "aws.s3")
+public record AwsS3Properties(String bucketName, String directory) {
+}

--- a/src/main/java/aubergine/dance/service/s3/S3StorageManager.java
+++ b/src/main/java/aubergine/dance/service/s3/S3StorageManager.java
@@ -4,6 +4,7 @@ import aubergine.dance.service.StorageManager;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 import software.amazon.awssdk.core.exception.SdkException;
 import software.amazon.awssdk.core.sync.RequestBody;
@@ -12,10 +13,8 @@ import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
 import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
 import software.amazon.awssdk.services.s3.model.PutObjectRequest;
 
-@Component
-@EnableConfigurationProperties(AwsS3Properties.class)
-@RequiredArgsConstructor
 @Slf4j
+@RequiredArgsConstructor
 public class S3StorageManager implements StorageManager {
 
     private final S3Client s3Client;

--- a/src/main/java/aubergine/dance/service/s3/S3StorageManager.java
+++ b/src/main/java/aubergine/dance/service/s3/S3StorageManager.java
@@ -1,0 +1,46 @@
+package aubergine.dance.service.s3;
+
+import aubergine.dance.service.StorageManager;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.stereotype.Component;
+import software.amazon.awssdk.core.exception.SdkException;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Response;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+@Component
+@EnableConfigurationProperties(AwsS3Properties.class)
+@RequiredArgsConstructor
+@Slf4j
+public class S3StorageManager implements StorageManager {
+
+    private final S3Client s3Client;
+    private final AwsS3Properties awsS3Properties;
+
+    @Override
+    public void createDirectory(String directory) {
+        PutObjectRequest request = PutObjectRequest.builder()
+                .bucket(awsS3Properties.bucketName())
+                .key(directory)
+                .build();
+        try {
+            s3Client.putObject(request, RequestBody.empty());
+        } catch (SdkException e) {
+            log.warn("Failed to create directory: {}", directory);
+        }
+    }
+
+    @Override
+    public boolean isDirectoryExists(String directory) {
+        ListObjectsV2Request listObjectsV2Request = ListObjectsV2Request.builder()
+                .bucket(awsS3Properties.bucketName())
+                .prefix(directory)
+                .build();
+        ListObjectsV2Response response = s3Client.listObjectsV2(listObjectsV2Request);
+        return response.hasContents();
+    }
+}

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -1,0 +1,50 @@
+spring:
+  profiles:
+    active: local
+
+  jpa:
+    properties:
+      hibernate:
+      show_sql: true
+    open-in-view: false
+    hibernate:
+      ddl-auto: create
+
+  datasource:
+    url: jdbc:h2:mem:testdb
+    username: sa
+    password:
+  h2:
+    console:
+      enabled: true
+
+server:
+  servlet:
+    encoding:
+      charset: UTF-8
+      force: true
+aws:
+  s3:
+    bucket-name: aubergine-dance
+    directory: problems/
+    credentials:
+      region: ap-northeast-2
+      access-key: TESTTESTTESTTESTTEST
+      secret-key: TESTTESTTESTTESTTESTTESTTEST
+
+aubergine:
+  init:
+    directories:
+      - problem_info.json
+      - statement/legend/
+      - statement/input_format/
+      - statement/output_format/
+      - statement/note/
+      - statement/examples/
+      - solution/
+      - in/
+      - out/
+      - checkers/
+      - validators/
+      - generators/
+      - misc/

--- a/src/test/java/aubergine/dance/service/ProblemInitializerTest.java
+++ b/src/test/java/aubergine/dance/service/ProblemInitializerTest.java
@@ -1,0 +1,30 @@
+package aubergine.dance.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+class ProblemInitializerTest {
+
+    private final StorageManager alreadyExistsStorageManager = new StorageManager() {
+        @Override
+        public void createDirectory(String directory) {
+            // no-op
+        }
+
+        @Override
+        public boolean isDirectoryExists(String directory) {
+            return true;
+        }
+    };
+
+    @Test
+    void 디렉토리가_이미_존재하는_경우_예외를_발생한다() {
+        ProblemInitDirectories directories = new ProblemInitDirectories(List.of("input"));
+        ProblemInitializer problemInitializer = new ProblemInitializer(alreadyExistsStorageManager, directories);
+
+        assertThatThrownBy(() -> problemInitializer.initializeProblem(1L))
+                .isInstanceOf(ProblemAlreadyExistsException.class);
+    }
+}


### PR DESCRIPTION
<!-- Write the related issue number below -->

- resolves #5 

---

### 🍆 Description
- 초기 문제 세팅 시 S3를 활용할 수 있도록 외부 의존성을 추가했어요.
- `StorageManager`가 디렉토리를 추가하고 존재 여부를 검사해요.

### 🥕 Changes
- S3가 서비스에 영향받지 않도록 인터페이스를 두어 의존성을 역전했어요. S3가 아닌 Directory 기반 로컬 파일도 잘 돌아갈 수 있습니다. ^-^ (이는 `StorageManagerConfig`에서 설정했어요)

### 🥒 Reminders
- 트랜잭션 보장이 안 돼요. 벌크 연산이 불가능한데, 중간에 실패한 것을 재시도하거나 한 번에 템플릿을 복사하는 방식을 생각해볼 수 있겠습니다.